### PR TITLE
Added parameters for CSV files

### DIFF
--- a/M365-Teams-PrüfungsTeams/01-CreateTeam.ps1
+++ b/M365-Teams-PrüfungsTeams/01-CreateTeam.ps1
@@ -19,10 +19,16 @@ param (
     [string]$Name,
 
     [Parameter(Mandatory=$true)]
-    [string]$Beschreibung
+    [string]$Beschreibung,
+
+    [Parameter(Mandatory=$true)]
+    [string]$LehrerCSV,
+
+    [Parameter(Mandatory=$true)]
+    [string]$SchuelerCSV
 )
 
-Import-Module MicrosoftTeams -RequiredVersion "1.1.9"
+Import-Module MicrosoftTeams -RequiredVersion "1.1.11"
 
 ###############################################################################
 #
@@ -37,6 +43,10 @@ Write-Host "| Team Name:         " -NoNewline
 Write-Host $Name -ForegroundColor Cyan
 Write-Host "| Team Beschreibung: " -NoNewline
 Write-Host $Beschreibung -ForegroundColor Cyan
+Write-Host "| Lehrer CSV-Datei:  " -NoNewline
+Write-Host $LehrerCSV -ForegroundColor Cyan
+Write-Host "| Schüler CSV-Datei: " -NoNewline
+Write-Host $SchuelerCSV -ForegroundColor Cyan
 Write-Host "==============================================================================="
 
 ###############################################################################
@@ -79,7 +89,7 @@ $GroupId = New-Team -DisplayName $Name -Description $Beschreibung -Visibility Pr
 #
 Write-Host ""
 Write-Host " - Erstelle Kanäle für die Prüfungen der SchülerInnen"
-Import-Csv -Path "schueler.csv" | ForEach-Object{
+Import-Csv -Path $SchuelerCSV | ForEach-Object{
     $ChannelName = $_.channel
     Write-Host "     - Erstelle Kanal: " -NoNewline
     Write-Host $ChannelName -ForegroundColor Cyan
@@ -92,7 +102,7 @@ Import-Csv -Path "schueler.csv" | ForEach-Object{
 #
 Write-Host ""
 Write-Host " - Berechtige LehrerInnen als Owner im Team"
-Import-Csv -Path "lehrer.csv" | ForEach-Object{ 
+Import-Csv -Path $LehrerCSV | ForEach-Object{ 
     $TeacherName = $_.upn
     Write-Host "     - Berechtige LehrerIn: " -NoNewline
     Write-Host $TeacherName -ForegroundColor Cyan
@@ -112,7 +122,7 @@ Get-TeamChannel -GroupId $GroupId.GroupId -MembershipType Private | ForEach-Obje
     Write-Host "     - Berechtige LehrerInnen im Kanal: " -NoNewline
     Write-Host $TeamChannelName -ForegroundColor Cyan
 
-    Import-Csv -Path "lehrer.csv" | ForEach-Object{ 
+    Import-Csv -Path $LehrerCSV | ForEach-Object{ 
         $Teacher = $_
         $TeacherName = $Teacher.upn
         Write-Host "         - Berechtige LehrerIn: " -NoNewline
@@ -136,7 +146,7 @@ Get-TeamChannel -GroupId $GroupId.GroupId -MembershipType Private | ForEach-Obje
 #
 Write-Host ""
 Write-Host " - Berechtige SchülerInnen als Member im Team"
-Import-Csv -Path "schueler.csv" | ForEach-Object{ 
+Import-Csv -Path $SchuelerCSV | ForEach-Object{ 
     $StudentName = $_.upn
     Write-Host "     - Berechtige SchülerIn: " -NoNewline
     Write-Host $StudentName  -ForegroundColor Cyan

--- a/M365-Teams-PrüfungsTeams/02-AddStudentsToChannels.ps1
+++ b/M365-Teams-PrüfungsTeams/02-AddStudentsToChannels.ps1
@@ -16,10 +16,13 @@
 [CmdletBinding()]
 param (
     [Parameter(Mandatory=$true)]
-    [string]$Name
+    [string]$Name,
+
+    [Parameter(Mandatory=$true)]
+    [string]$SchuelerCSV
 )
 
-Import-Module MicrosoftTeams -RequiredVersion "1.1.9"
+Import-Module MicrosoftTeams -RequiredVersion "1.1.11"
 
 ###############################################################################
 #
@@ -32,8 +35,10 @@ Write-Host "| SchülerInnen werden zu Ihren Kanälen hinzugefügt"
 Write-Host "| " -NoNewline
 Write-Host "Zugriff wird erlaubt" -ForegroundColor Green
 Write-Host "|"
-Write-Host "| Team Name: " -NoNewline
+Write-Host "| Team Name:         " -NoNewline
 Write-Host $Name -ForegroundColor Cyan
+Write-Host "| Schüler CSV-Datei: " -NoNewline
+Write-Host $SchuelerCSV -ForegroundColor Cyan
 Write-Host "==============================================================================="
 
 ###############################################################################
@@ -58,7 +63,7 @@ Get-TeamChannel -GroupId $GroupId.GroupId -MembershipType Private | ForEach-Obje
     Write-Host " - Füge SchülerInnen zum Kanal hinzu: " -NoNewline
     Write-Host $TeamChannelName -ForegroundColor Cyan
 
-    Import-Csv -Path "schueler.csv" | ForEach-Object{ 
+    Import-Csv -Path $SchuelerCSV | ForEach-Object{ 
         $Student = $_
         $StudentName = $Student.upn
 

--- a/M365-Teams-PrüfungsTeams/03-RemoveStudentsFromChannels.ps1
+++ b/M365-Teams-PrüfungsTeams/03-RemoveStudentsFromChannels.ps1
@@ -16,10 +16,13 @@
 [CmdletBinding()]
 param (
     [Parameter(Mandatory=$true)]
-    [string]$Name
+    [string]$Name,
+
+    [Parameter(Mandatory=$true)]
+    [string]$SchuelerCSV
 )
 
-Import-Module MicrosoftTeams -RequiredVersion "1.1.9"
+Import-Module MicrosoftTeams -RequiredVersion "1.1.11"
 
 ###############################################################################
 #
@@ -32,8 +35,10 @@ Write-Host "| SchülerInnen werden aus Ihren Kanälen entfernt"
 Write-Host "| " -NoNewline
 Write-Host "Zugriff wird verweigert" -ForegroundColor Red
 Write-Host "|"
-Write-Host "| Team Name: " -NoNewline
+Write-Host "| Team Name:         " -NoNewline
 Write-Host $Name -ForegroundColor Cyan
+Write-Host "| Schüler CSV-Datei: " -NoNewline
+Write-Host $SchuelerCSV -ForegroundColor Cyan
 Write-Host "==============================================================================="
 
 ###############################################################################
@@ -58,7 +63,7 @@ Get-TeamChannel -GroupId $GroupId.GroupId -MembershipType Private | ForEach-Obje
     Write-Host " - Entferne SchülerInnen aus dem Kanal: " -NoNewline
     Write-Host $TeamChannelName -ForegroundColor Cyan
 
-    Import-Csv -Path "schueler.csv" | ForEach-Object{ 
+    Import-Csv -Path $SchuelerCSV | ForEach-Object{ 
         $Student = $_
         $StudentName = $Student.upn
 

--- a/M365-Teams-PrüfungsTeams/04-ArchiveTeam.ps1
+++ b/M365-Teams-PrüfungsTeams/04-ArchiveTeam.ps1
@@ -19,7 +19,7 @@ param (
     [string]$Name
 )
 
-Import-Module MicrosoftTeams -RequiredVersion "1.1.9"
+Import-Module MicrosoftTeams -RequiredVersion "1.1.11"
 
 ###############################################################################
 #
@@ -30,7 +30,7 @@ Write-Host ""
 Write-Host "==============================================================================="
 Write-Host "| Team für Prüfungen wird archiviert"
 Write-Host "|"
-Write-Host "| Team Name:         " -NoNewline
+Write-Host "| Team Name: " -NoNewline
 Write-Host $Name -ForegroundColor Cyan
 Write-Host "==============================================================================="
 

--- a/M365-Teams-PrüfungsTeams/README.md
+++ b/M365-Teams-PrüfungsTeams/README.md
@@ -23,7 +23,7 @@ Das Skript muss mit zwei Parametern aufgerufen werden:
   - Name  
   - Beschreibung  
   ```PowerShell
-  .\01-CreateTeam.ps1 -Name "Prüfung 2020-21" -Beschreibung "Prüfungen im Jahrgang 2020/21"
+  .\01-CreateTeam.ps1 -Name "Prüfung 2020-21" -Beschreibung "Prüfungen im Jahrgang 2020/21" -LehrerCSV .\lehrer.csv -SchuelerCSV .\schueler.csv
   ```
 > :exclamation: Pro Team können maximal 30 private Kanäle angelegt werden. Somit können maximal 30 SchülerInnen pro Team die Prüfung durchführen. Bei mehr Schülern müssen evtl. mehrere Teams erstellt werden.
 
@@ -32,7 +32,7 @@ Dieses Skript fügt jeden SchülerIn mithilfe der _schueler.csv_ als Member zu s
 Das Skript muss mit einem Parameter aufgerufen werden:  
   - Name  
   ```PowerShell
-  .\02-AddStudentsToChannels.ps1 -Name "Prüfung 2020-21"
+  .\02-AddStudentsToChannels.ps1 -Name "Prüfung 2020-21" -SchuelerCSV .\schueler.csv
   ```
 
 - __03-RemoveStudentsFromChannels.ps1__  
@@ -40,7 +40,7 @@ Dieses Skript entfernt jeden SchülerIn mithilfe der _schueler.csv_ aus seinem K
 Das Skript muss mit einem Parameter aufgerufen werden:  
   - Name  
   ```PowerShell
-  .\03-RemoveStudentsFromChannels.ps1 -Name "Prüfung 2020-21"
+  .\03-RemoveStudentsFromChannels.ps1 -Name "Prüfung 2020-21" -SchuelerCSV .\schueler.csv
   ```
 
 - __04-ArchiveTeam.ps1__  
@@ -99,5 +99,5 @@ Alternativ geht dieses auch mittels der [Anleitung für die manuelle Installatio
 Um nun Teams aus der PowerShell verwalten zu können, [benötigen wir das Teams-PowerShell-Modul](https://docs.microsoft.com/de-de/MicrosoftTeams/teams-powershell-install). Dazu muss der folgende Befehl in der gerade installierten PowerShell ausgeführt werden.
 
 ```Powershell
-Install-Module MicrosoftTeams -AllowPrerelease -RequiredVersion "1.1.9-preview" -Scope CurrentUser
+Install-Module MicrosoftTeams -AllowPrerelease -RequiredVersion "1.1.11-preview" -Scope CurrentUser
 ```


### PR DESCRIPTION
Mit dem Pull Request kann man nun bei Aufruf der Skripte definieren welche Lehrer und Schüler CSV-Datei verwendet werden soll. Dadurch wird es möglich mehrere Teams zu erstellen, ohne den Ordner kopieren zu müssen.